### PR TITLE
get-users-from-skills API updated with changed response body

### DIFF
--- a/userprofile/src/main/java/com/collreach/userprofile/controller/UserProfileController.java
+++ b/userprofile/src/main/java/com/collreach/userprofile/controller/UserProfileController.java
@@ -65,7 +65,7 @@ public class UserProfileController {
         return ResponseEntity.ok().body(msg);
     }
 
-    @PostMapping(path = "/get-user-from-skills")
+    @PostMapping(path = "/get-users-from-skills")
     public ResponseEntity<UsersSkillsResponse> getUserFromSkills(@RequestBody UsersFromSkillsRequest usersFromSkillsRequest){
         UsersSkillsResponse msg = userProfileService.getUsersFromSkills(usersFromSkillsRequest);
         return ResponseEntity.ok().body(msg);

--- a/userprofile/src/main/java/com/collreach/userprofile/model/response/UserProfileSkillsResponse.java
+++ b/userprofile/src/main/java/com/collreach/userprofile/model/response/UserProfileSkillsResponse.java
@@ -1,0 +1,34 @@
+package com.collreach.userprofile.model.response;
+
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+public class UserProfileSkillsResponse {
+    String profileAccessKey;
+    SortedMap<String, Integer> skillsUpvote;
+
+    public UserProfileSkillsResponse() {
+        this.skillsUpvote = new TreeMap<>();
+    }
+
+    public UserProfileSkillsResponse(String profileAccessKey) {
+        this.profileAccessKey = profileAccessKey;
+        this.skillsUpvote = new TreeMap<>();
+    }
+
+    public String getProfileAccessKey() {
+        return profileAccessKey;
+    }
+
+    public void setProfileAccessKey(String profileAccessKey) {
+        this.profileAccessKey = profileAccessKey;
+    }
+
+    public SortedMap<String, Integer> getSkillsUpvote() {
+        return skillsUpvote;
+    }
+
+    public void setSkillsUpvote(SortedMap<String, Integer> skillsUpvote) {
+        this.skillsUpvote = skillsUpvote;
+    }
+}

--- a/userprofile/src/main/java/com/collreach/userprofile/model/response/UsersSkillsResponse.java
+++ b/userprofile/src/main/java/com/collreach/userprofile/model/response/UsersSkillsResponse.java
@@ -1,16 +1,26 @@
 package com.collreach.userprofile.model.response;
 
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.*;
 
+//public class UsersSkillsResponse {
+//    private HashMap<String, ArrayList<String>> usersSkills;
+//
+//    public HashMap<String, ArrayList<String>> getUsersSkills() {
+//        return usersSkills;
+//    }
+//
+//    public void setUsersSkills(HashMap<String, ArrayList<String>> usersSkills) {
+//        this.usersSkills = usersSkills;
+//    }
+//}
 public class UsersSkillsResponse {
-    private HashMap<String, ArrayList<String>> usersSkills;
+    private LinkedHashMap<String, UserProfileSkillsResponse> usersSkills;
 
-    public HashMap<String, ArrayList<String>> getUsersSkills() {
+    public LinkedHashMap<String, UserProfileSkillsResponse> getUsersSkills() {
         return usersSkills;
     }
 
-    public void setUsersSkills(HashMap<String, ArrayList<String>> usersSkills) {
+    public void setUsersSkills(LinkedHashMap<String, UserProfileSkillsResponse> usersSkills) {
         this.usersSkills = usersSkills;
     }
 }


### PR DESCRIPTION
In this pull request:
- get-users-from-skills API updated in userprofile module.
- Updation:
    - response changed.
    - New response has the following format now in which names are sorted
      according to no. of skills they have(in descending order):
 ```
{
  "usersSkills": {
    "Ayush": {
      "profileAccessKey": "ayush1830667372",
      "skillsUpvote": {
        "AI": 0,
        "Android": 0,
        "Java": 0,
        "ML": 0,
        "React": 5,
        "Spring": 1
      }
    },
    "Ayush Choudhary": {
      "profileAccessKey": "ayush1983863846",
      "skillsUpvote": {
        "Java": 3,
        "Python": 1,
        "Spring": 4
      }
    },
    "Arpit Kher": {
      "profileAccessKey": "arpit1829883456",
      "skillsUpvote": {
        "Python": 0,
        "React": 0,
        "Spring": 0
      }
    },
    "Ayush Kumar": {
      "profileAccessKey": "",
      "skillsUpvote": {
        "React": 0,
        "Spring": 3
      }
    },
    "Arun Kushwaha": {
      "profileAccessKey": "",
      "skillsUpvote": {
        "Python": 0,
        "Spring": 0
      }
    },
    "Akash": {
      "profileAccessKey": "",
      "skillsUpvote": {
        "Python": 0
      }
    }
  }
}
```