### PR TITLE
get-users-from-skills returns data with sorted skills also

### DIFF
--- a/userprofile/src/main/java/com/collreach/userprofile/model/response/UserProfileSkillsResponse.java
+++ b/userprofile/src/main/java/com/collreach/userprofile/model/response/UserProfileSkillsResponse.java
@@ -1,19 +1,20 @@
 package com.collreach.userprofile.model.response;
 
+import java.util.LinkedHashMap;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
 public class UserProfileSkillsResponse {
     String profileAccessKey;
-    SortedMap<String, Integer> skillsUpvote;
+    LinkedHashMap<String, Integer> skillsUpvote;
 
     public UserProfileSkillsResponse() {
-        this.skillsUpvote = new TreeMap<>();
+        this.skillsUpvote = new LinkedHashMap<>();
     }
 
     public UserProfileSkillsResponse(String profileAccessKey) {
         this.profileAccessKey = profileAccessKey;
-        this.skillsUpvote = new TreeMap<>();
+        this.skillsUpvote = new LinkedHashMap<>();
     }
 
     public String getProfileAccessKey() {
@@ -24,11 +25,11 @@ public class UserProfileSkillsResponse {
         this.profileAccessKey = profileAccessKey;
     }
 
-    public SortedMap<String, Integer> getSkillsUpvote() {
+    public LinkedHashMap<String, Integer> getSkillsUpvote() {
         return skillsUpvote;
     }
 
-    public void setSkillsUpvote(SortedMap<String, Integer> skillsUpvote) {
+    public void setSkillsUpvote(LinkedHashMap<String, Integer> skillsUpvote) {
         this.skillsUpvote = skillsUpvote;
     }
 }

--- a/userprofile/src/main/java/com/collreach/userprofile/service/impl/UserProfileServiceImpl.java
+++ b/userprofile/src/main/java/com/collreach/userprofile/service/impl/UserProfileServiceImpl.java
@@ -164,7 +164,7 @@ public class UserProfileServiceImpl implements UserProfileService {
     @Override
     public UsersSkillsResponse getUsersFromSkills(UsersFromSkillsRequest usersFromSkillsRequest){
         List<String> list = usersFromSkillsRequest.getSkills();
-        SortedMap<String, UserProfileSkillsResponse> userSkillsMap = new TreeMap<>();
+        LinkedHashMap<String, UserProfileSkillsResponse> userSkillsMap = new LinkedHashMap<>();
         LinkedHashMap<String, UserProfileSkillsResponse> userSkillsSortedMap = new LinkedHashMap<>();
 
         for(String skill: list){
@@ -207,8 +207,20 @@ public class UserProfileServiceImpl implements UserProfileService {
                     userSkillsSortedMap.put(x.getKey(),x.getValue())
                 );
 
+        for(Map.Entry<String, UserProfileSkillsResponse> userProfileSkills: userSkillsSortedMap.entrySet()){
+                var sortedSkillsMap =
+                        userProfileSkills.getValue().getSkillsUpvote()
+                        .entrySet()
+                        .stream()
+                        .sorted((i1, i2) -> i2.getValue().compareTo(i1.getValue()))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
+                                (e1, e2) -> e1, LinkedHashMap::new));
+                userProfileSkills.getValue().setSkillsUpvote(sortedSkillsMap);
+        }
+
         UsersSkillsResponse usersSkillsResponse = new UsersSkillsResponse();
         usersSkillsResponse.setUsersSkills(userSkillsSortedMap);
+        userSkillsMap = null;
         return usersSkillsResponse;
     }
 


### PR DESCRIPTION
In this pull Request:
- **get-users-from-skills** _API_ updated with:
    - data inside **skillsUpvote** is also **sorted** in **decreasing order**.
    - In previous Pull Request #44 whole data is sorted by skillsUpvote size only, in decreasing order.
```
{
  "usersSkills": {
    "Ayush": {
      "profileAccessKey": "ayush1830667372",
      "skillsUpvote": {
        "React": 5,
        "Spring": 1,
        "Java": 0,
        "AI": 0,
        "ML": 0,
        "Android": 0
      }
    },
    "Ayush Choudhary": {
      "profileAccessKey": "ayush1983863846",
      "skillsUpvote": {
        "Spring": 4,
        "Java": 3,
        "Python": 1
      }
    },
    "Arpit Kher": {
      "profileAccessKey": "arpit1829883456",
      "skillsUpvote": {
        "Python": 0,
        "Spring": 0,
        "React": 0
      }
    },
    "Ayush Kumar": {
      "profileAccessKey": "",
      "skillsUpvote": {
        "Spring": 3,
        "React": 0
      }
    },
    "Arun Kushwaha": {
      "profileAccessKey": "",
      "skillsUpvote": {
        "Python": 0,
        "Spring": 0
      }
    },
    "Akash": {
      "profileAccessKey": "",
      "skillsUpvote": {
        "Python": 0
      }
    }
  }
}
```