### PR TITLE
Add update-likes, update-views APIs in posts & update-votes in polls

### DIFF
--- a/posts/src/main/java/com/collreach/posts/controller/PollsController.java
+++ b/posts/src/main/java/com/collreach/posts/controller/PollsController.java
@@ -4,10 +4,7 @@ import com.collreach.posts.model.requests.CreatePollRequest;
 import com.collreach.posts.service.PollsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @CrossOrigin("*")
@@ -16,9 +13,18 @@ public class PollsController {
     @Autowired
     private PollsService pollsService;
 
-    @PostMapping(path = "create-poll")
+    @PostMapping(path = "/create-poll")
     public ResponseEntity<String> createPoll(@RequestBody CreatePollRequest createPollRequest){
         String msg = pollsService.createPoll(createPollRequest);
+        return ResponseEntity.ok().body(msg);
+    }
+
+    @PutMapping(path = "/update-answer-votes/{username}/{pollId}/{answerId}")
+    public ResponseEntity<String> updateAnswerVotes(@PathVariable(value = "username") String userName,
+                                                     @PathVariable(value = "pollId") int pollId,
+                                                     @PathVariable(value = "answerId") int answerId){
+
+        String msg = pollsService.updatesAnswersVotes(userName, pollId, answerId);
         return ResponseEntity.ok().body(msg);
     }
 }

--- a/posts/src/main/java/com/collreach/posts/controller/PostController.java
+++ b/posts/src/main/java/com/collreach/posts/controller/PostController.java
@@ -4,6 +4,7 @@ package com.collreach.posts.controller;
 import com.collreach.posts.model.repositories.posts.MessagesRepository;
 import com.collreach.posts.model.requests.CreatePostRequest;
 import com.collreach.posts.model.response.MessagesResponse;
+import com.collreach.posts.responses.ResponseMessage;
 import com.collreach.posts.service.PostService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -64,5 +65,19 @@ public class PostController {
         //ImagesResponse imagesResponse = postService.getPostsByPagination(pageNo, pageSize);
         MessagesResponse messagesResponse = postService.getPostsAndPollsPaginationFilteredByVisibility(pageNo, pageSize,visibility);
         return ResponseEntity.ok().body(messagesResponse);
+    }
+
+    @PutMapping(path = "/update-post-views/{username}/{messageId}")
+    public ResponseEntity<String> updatePostViews(@PathVariable(value = "username") String userName,
+                                                   @PathVariable(value = "messageId") Integer messageId){
+        String msg = postService.updatePostViews(userName, messageId);
+        return ResponseEntity.ok().body(msg);
+    }
+
+    @PutMapping(path = "/update-post-likes/{username}/{messageId}")
+    public ResponseEntity<String> updatePostLikes(@PathVariable(value = "username") String userName,
+                                                  @PathVariable(value = "messageId") Integer messageId){
+        String msg = postService.updatePostLikes(userName, messageId);
+        return ResponseEntity.ok().body(msg);
     }
 }

--- a/posts/src/main/java/com/collreach/posts/model/bo/polls/PollAnswers.java
+++ b/posts/src/main/java/com/collreach/posts/model/bo/polls/PollAnswers.java
@@ -1,9 +1,12 @@
 package com.collreach.posts.model.bo.polls;
 
 
+import org.hibernate.annotations.DynamicUpdate;
+
 import javax.persistence.*;
 
 @Entity
+@DynamicUpdate
 @Table(name = "answers")
 public class PollAnswers {
 

--- a/posts/src/main/java/com/collreach/posts/model/bo/posts/Messages.java
+++ b/posts/src/main/java/com/collreach/posts/model/bo/posts/Messages.java
@@ -2,12 +2,14 @@ package com.collreach.posts.model.bo.posts;
 
 import com.collreach.posts.model.bo.Users;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;
 import java.sql.Time;
 import java.util.Date;
 
 @Entity
+@DynamicUpdate
 @Table(name = "messages")
 public class Messages {
 

--- a/posts/src/main/java/com/collreach/posts/model/bo/posts/SeenAndLiked.java
+++ b/posts/src/main/java/com/collreach/posts/model/bo/posts/SeenAndLiked.java
@@ -7,7 +7,7 @@ import javax.persistence.*;
 @Entity
 @Table(name = "seen")
 @IdClass(UserMessageKey.class)
-public class Seen {
+public class SeenAndLiked {
 
     @Id
     @ManyToOne
@@ -20,9 +20,12 @@ public class Seen {
     private Messages messageId;
 
     @Column(name = "seen")
-    private char seen;
+    private Character seen;
 
-    public Seen() {
+    @Column(name = "liked")
+    private Character liked;
+
+    public SeenAndLiked() {
     }
 
     public Users getUserId() {
@@ -41,11 +44,19 @@ public class Seen {
         this.messageId = messageId;
     }
 
-    public char getSeen() {
+    public Character getSeen() {
         return seen;
     }
 
-    public void setSeen(char seen) {
+    public void setSeen(Character seen) {
         this.seen = seen;
+    }
+
+    public Character getLiked() {
+        return liked;
+    }
+
+    public void setLiked(Character liked) {
+        this.liked = liked;
     }
 }

--- a/posts/src/main/java/com/collreach/posts/model/repositories/polls/PollAnswersRepository.java
+++ b/posts/src/main/java/com/collreach/posts/model/repositories/polls/PollAnswersRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.repository.CrudRepository;
 
 import java.util.List;
 
-public interface AnswersRepository extends CrudRepository<PollAnswers, Integer> {
+public interface PollAnswersRepository extends CrudRepository<PollAnswers, Integer> {
     public List<PollAnswers> findAllByPollId(Polls pollId);
 }

--- a/posts/src/main/java/com/collreach/posts/model/repositories/posts/SeenAndLikedRepository.java
+++ b/posts/src/main/java/com/collreach/posts/model/repositories/posts/SeenAndLikedRepository.java
@@ -1,8 +1,8 @@
 package com.collreach.posts.model.repositories.posts;
 
-import com.collreach.posts.model.bo.posts.Seen;
+import com.collreach.posts.model.bo.posts.SeenAndLiked;
 import com.collreach.posts.model.bo.posts.UserMessageKey;
 import org.springframework.data.repository.CrudRepository;
 
-public interface SeenRepository extends CrudRepository<Seen, UserMessageKey> {
+public interface SeenAndLikedRepository extends CrudRepository<SeenAndLiked, UserMessageKey> {
 }

--- a/posts/src/main/java/com/collreach/posts/model/response/MessageResponse.java
+++ b/posts/src/main/java/com/collreach/posts/model/response/MessageResponse.java
@@ -14,6 +14,7 @@ public class MessageResponse {
     private Date createDate;
 
     /*------Posts------*/
+    private int messageId;
     private String filename;
     private String filetype;
     private byte[] image;
@@ -22,6 +23,7 @@ public class MessageResponse {
     private String message;
 
     /*------Polls------*/
+    private int pollId;
     private String question;
     private List<PollAnswersResponse> answers;
 
@@ -34,11 +36,12 @@ public class MessageResponse {
         this.image = image;
     }
 
-    public MessageResponse(String filename, String filetype,
+    public MessageResponse(int messageId, String filename, String filetype,
                            byte[] image, String visibility,
                            int lifetimeInWeeks, int recurrences,
                            int likes, int views, String message,
                            Date uploadTime, Date createDate) {
+        this.messageId = messageId;
         this.filename = filename;
         this.filetype = filetype;
         this.image = image;
@@ -154,5 +157,21 @@ public class MessageResponse {
 
     public void setAnswers(List<PollAnswersResponse> answers) {
         this.answers = answers;
+    }
+
+    public int getMessageId() {
+        return messageId;
+    }
+
+    public void setMessageId(int messageId) {
+        this.messageId = messageId;
+    }
+
+    public int getPollId() {
+        return pollId;
+    }
+
+    public void setPollId(int pollId) {
+        this.pollId = pollId;
     }
 }

--- a/posts/src/main/java/com/collreach/posts/responses/ResponseMessage.java
+++ b/posts/src/main/java/com/collreach/posts/responses/ResponseMessage.java
@@ -1,9 +1,13 @@
 package com.collreach.posts.responses;
 
 public class ResponseMessage {
-    public static final String PROCESSING_ERROR = "Error processing data!";
-    public static final String USER_NOT_FOUND = "User not found";
-    public static final String SUCCESSFULLY_DONE = "Done Successfully";
-    public static final String POLL_CREATED = "Poll has been successfully created.";
-    public static final String POST_CREATED = "Post has been successfully created.";
+    public static final String PROCESSING_ERROR = "Error: Processing error!";
+    public static final String USER_NOT_FOUND = "Error: User not found";
+    public static final String USER_ALREADY_VOTED = "Error: User Already Voted";
+    public static final String USER_ALREADY_SEEN = "Error: User Already Seen";
+    public static final String USER_ALREADY_LIKED = "Error: User Already Liked";
+
+    public static final String SUCCESSFULLY_DONE = "Success: Done Successfully";
+    public static final String POLL_CREATED = "Success: Poll has been successfully created.";
+    public static final String POST_CREATED = "Success: Post has been successfully created.";
 }

--- a/posts/src/main/java/com/collreach/posts/service/PollsService.java
+++ b/posts/src/main/java/com/collreach/posts/service/PollsService.java
@@ -8,4 +8,5 @@ import java.util.LinkedHashSet;
 public interface PollsService {
     public String createPoll(CreatePollRequest createPollRequest);
     public LinkedHashSet<MessageResponse> getPolls(Integer pageNo, Integer pageSize, String visibility);
+    public String updatesAnswersVotes(String userName, int pollId, int answerId);
 }

--- a/posts/src/main/java/com/collreach/posts/service/PostService.java
+++ b/posts/src/main/java/com/collreach/posts/service/PostService.java
@@ -18,4 +18,6 @@ public interface PostService {
     public MessagesResponse getPostsByPagination(Integer pageNo, Integer pageSize);
     public MessagesResponse getPostsAndPollsPaginationFilteredByVisibility(Integer pageNo, Integer pageSize, String visibility);
     public LinkedHashSet<MessageResponse> mergeSets(LinkedHashSet<MessageResponse> posts, LinkedHashSet<MessageResponse> polls);
-    }
+    String updatePostViews(String userName, int messageId);
+    String updatePostLikes(String userName, int messageId);
+}

--- a/posts/src/main/java/com/collreach/posts/service/impl/PollsServiceImpl.java
+++ b/posts/src/main/java/com/collreach/posts/service/impl/PollsServiceImpl.java
@@ -3,9 +3,12 @@ package com.collreach.posts.service.impl;
 import com.collreach.posts.model.bo.Users;
 import com.collreach.posts.model.bo.polls.PollAnswers;
 import com.collreach.posts.model.bo.polls.Polls;
+import com.collreach.posts.model.bo.polls.UserPollKey;
+import com.collreach.posts.model.bo.polls.UsersPolled;
 import com.collreach.posts.model.repositories.UsersRepository;
-import com.collreach.posts.model.repositories.polls.AnswersRepository;
+import com.collreach.posts.model.repositories.polls.PollAnswersRepository;
 import com.collreach.posts.model.repositories.polls.PollsRepository;
+import com.collreach.posts.model.repositories.polls.UsersPolledRepository;
 import com.collreach.posts.model.requests.CreatePollRequest;
 import com.collreach.posts.model.response.MessageResponse;
 import com.collreach.posts.model.response.PollAnswersResponse;
@@ -33,7 +36,10 @@ public class PollsServiceImpl implements PollsService {
     PollsRepository pollsRepository;
 
     @Autowired
-    AnswersRepository answersRepository;
+    PollAnswersRepository pollAnswersRepository;
+
+    @Autowired
+    UsersPolledRepository usersPolledRepository;
 
     @Override
     @Transactional
@@ -56,7 +62,7 @@ public class PollsServiceImpl implements PollsService {
                     PollAnswers pollAnswers = new PollAnswers();
                     pollAnswers.setPollId(savedPoll);
                     pollAnswers.setAnswer(answer);
-                    answersRepository.save(pollAnswers);
+                    pollAnswersRepository.save(pollAnswers);
                 }
                 return ResponseMessage.POLL_CREATED;
             }catch(Exception e){
@@ -78,6 +84,7 @@ public class PollsServiceImpl implements PollsService {
         pollsRepository.findAllByVisibilityOrVisibility(visibility,"college", paging)
                 .forEach(poll -> {
                     MessageResponse messageResponse = new MessageResponse();
+                    messageResponse.setPollId(poll.getPollId());
                     messageResponse.setQuestion(poll.getQuestion());
                     messageResponse.setLifetimeInWeeks(poll.getValidityInWeeks());
                     messageResponse.setCreateDate(poll.getDateCreated());
@@ -85,7 +92,7 @@ public class PollsServiceImpl implements PollsService {
                     messageResponse.setVisibility(poll.getVisibility());
                     messageResponse.setRecurrences(poll.getRecurrences());
                     List<PollAnswersResponse> pollAnswers = new ArrayList<>();
-                    answersRepository.findAllByPollId(poll).forEach(answer -> {
+                    pollAnswersRepository.findAllByPollId(poll).forEach(answer -> {
                         PollAnswersResponse pollAnswersResponse = new PollAnswersResponse(
                                 answer.getAnswerId(), answer.getAnswer(), answer.getVotes()
                         );
@@ -95,5 +102,35 @@ public class PollsServiceImpl implements PollsService {
                     set.add(messageResponse);
                 });
         return set;
+    }
+
+    @Override
+    public String updatesAnswersVotes(String userName, int pollId, int answerId) {
+        Optional<Users> user = usersRepository.findByUserName(userName);
+        if(user.isPresent()){
+            Optional<Polls> poll = pollsRepository.findById(pollId);
+            Optional<PollAnswers> pollAnswer = pollAnswersRepository.findById(answerId);
+            Optional<UsersPolled> userAlreadyPolled = usersPolledRepository
+                    .findById(new UserPollKey(user.get().getUserId(),pollId));
+
+            if(poll.isPresent() && pollAnswer.isPresent() && !userAlreadyPolled.isPresent()){
+                try {
+                    int previousVotes = pollAnswer.get().getVotes();
+                    pollAnswer.get().setVotes(previousVotes+1);
+                    UsersPolled usersPolled = new UsersPolled();
+                    usersPolled.setPollId(poll.get());
+                    usersPolled.setUserId(user.get());
+                    usersPolled.setIfVoted('T');
+                    usersPolledRepository.save(usersPolled);
+                    pollAnswersRepository.save(pollAnswer.get());
+                    return "Success: " + pollAnswer.get().getVotes();
+                }catch(Exception e){
+                    return ResponseMessage.PROCESSING_ERROR;
+                }
+            }else{
+                return ResponseMessage.USER_ALREADY_VOTED;
+            }
+        }
+        return ResponseMessage.USER_NOT_FOUND;
     }
 }


### PR DESCRIPTION
In this Pull Request:
- **Update Likes** & **Update Views** APIs added for Collreach-posts
- **Update Answer Votes** API added for CollReach-polls
- **Seen** Entity Renamed to **SeenAndLiked** Entity because of addition of new column **"liked".**
- **PollAnswers** & **Messages** are annotated with `@DynamicUpdate` to make changes to only those columns where the change is required as previously all the columns were updating even for one column updated.
- **MessageResponse** now add two more field `MessageId` & `pollId` in response:
    - **MessageId** for posts
    - **PollId** for polls
- New **ResponseMessage** added
    - `USER_ALREADY_VOTED`
    - `USER_ALREADY_SEEN`
    - `USER_ALREADY_LIKED`
    - and previous messages refactored.